### PR TITLE
set unique metric prefixes

### DIFF
--- a/mysql/innodb-index-stats.yml
+++ b/mysql/innodb-index-stats.yml
@@ -16,13 +16,13 @@ mysql_innodb_index_stats:
     - index_name:
         usage: "LABEL"
         description: "Index name"
-mysql_innodb_index_stats:
-   query: "select database_name as schema_name,table_name,index_name,stat_value*@@innodb_page_size as leaf_pages_size_bytes from mysql.innodb_index_stats where stat_name='n_leaf_pages';"
+mysql_innodb_index_stats_leaf:
+   query: "select database_name as schema_name,table_name,index_name,stat_value*@@innodb_page_size as pages_size_bytes from mysql.innodb_index_stats where stat_name='n_leaf_pages';"
    metrics:
     - table_name:
         usage: "LABEL"
         description: "Table name"
-    - leaf_pages_size_bytes:
+    - pages_size_bytes:
         usage: "GAUGE"
         description: "Leaf Pages Size in Bytes"
     - schema_name:


### PR DESCRIPTION
Issue:
Metrics Prefix has to be unique. If it's not then the last one only is used.

Details:
https://forums.percona.com/t/custom-mysql-query-problem/8675

Here is a result after the current fix: 
![Screenshot_20210107_115511](https://user-images.githubusercontent.com/25184101/103880128-6195c100-50e1-11eb-9fbf-3e233ed4a53f.png)
