### PR TITLE
PMM-8618 Fix for the PG Table Sizes custom query

### DIFF
--- a/postgresql/pg_table_size-details.yaml
+++ b/postgresql/pg_table_size-details.yaml
@@ -1,9 +1,12 @@
 pg_class:
-  query: "SELECT current_database() datname, relname, CAST(reltuples AS BIGINT) table_rows, pg_total_relation_size(oid) disk_usage_table_bytes, pg_indexes_size(oid) disk_usage_index_bytes, COALESCE(pg_total_relation_size(reltoastrelid),0) disk_usage_toast_bytes FROM pg_class"
+  query: "SELECT current_database() datname, pgn.nspname schemaname, pgc.relname, CAST(pgc.reltuples AS BIGINT) table_rows, pg_total_relation_size(pgc.oid) disk_usage_table_bytes, pg_indexes_size(pgc.oid) disk_usage_index_bytes, COALESCE(pg_total_relation_size(pgc.reltoastrelid), 0) disk_usage_toast_bytes FROM pg_class pgc JOIN pg_namespace pgn ON pgc.relnamespace = pgn.oid"
   metrics:
     - datname:
         usage: "LABEL"
         description: "Name of the database that this table is in"
+    - schemaname:
+        usage: "LABEL"
+        description: "Name of the schema that this table is in"
     - relname:
         usage: "LABEL"
         description: "Name of the table, index, view, etc."


### PR DESCRIPTION
Previous version of the query didn't take schemas into account. Thus, having `schema1.tblName` and `schema2.tblName` resulted in pmm-agent logs
being flooded with errors regarding duplicate metrics.
```
<metric> ... was collected before with the same name and label values
```
This has been fixed now. Example query results:
```
 datname |     schemaname     |         relname         | table_rows | disk_usage_table_bytes ...
---------+--------------------+-------------------------+------------+------------------------...
 test    | public             | test_table_schema       |          0 |                  24576 ...
 test    | public             | test_table_schema_pkey  |          0 |                  16384 ...
 test    | nonpublic          | test_table_schema       |          0 |                  24576 ...
 test    | nonpublic          | test_table_schema_pkey  |          0 |                  16384 ...
```